### PR TITLE
Support non blob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,6 @@ tags
 
 # Unit tests
 /cmd/artifact/testdata/
-/testdata/10mb.dat
-/testdata/request.dat
+/integration/testdata/
+/testdata/
+

--- a/body_test.go
+++ b/body_test.go
@@ -16,7 +16,7 @@ func setup(t *testing.T) (*os.File, []byte, func()) {
 	var b bytes.Buffer
 	var err error
 
-	if err = os.MkdirAll("testdata", os.FileMode(0755)); err != nil {
+	if err = os.MkdirAll("testdata", 0755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/body_test.go
+++ b/body_test.go
@@ -16,6 +16,10 @@ func setup(t *testing.T) (*os.File, []byte, func()) {
 	var b bytes.Buffer
 	var err error
 
+	if err = os.MkdirAll("testdata", os.FileMode(0755)); err != nil {
+		t.Fatal(err)
+	}
+
 	file, err := ioutil.TempFile("testdata", "body-test")
 	if err != nil {
 		t.Fatal(err)

--- a/errors.go
+++ b/errors.go
@@ -24,3 +24,11 @@ var ErrBadOutputWriter = newError(nil, "output writer is not empty")
 
 // ErrBadSize is returned when a part size or chunk size is invalid
 var ErrBadSize = newError(nil, "invalid part or chunk size")
+
+// ErrErr is an error that marks an error artifact error not library error
+//NOTE: this is not an error in this library, nor is it an error in the
+//taskcluster client.  This signifies that the artifact was created as the
+//error type.  If you're here wondering why you can't download the artifact you
+//requested, what's actually happened is that whatever should've created your
+//artifact broke and stored an Error artifact in its stead
+var ErrErr = newError(nil, "artifact is an error")

--- a/interface.go
+++ b/interface.go
@@ -40,6 +40,7 @@ type Client struct {
 	chunkSize               int
 	multipartPartChunkCount int
 	AllowInsecure           bool
+	clientForBlindRedirects *http.Client
 }
 
 // DefaultChunkSize is 128KB
@@ -48,14 +49,33 @@ const DefaultChunkSize int = 128 * 1024
 // DefaultPartSize is 100MB
 const DefaultPartSize int = 100 * 1024 * 1024 / DefaultChunkSize
 
+// So in the ideal world, what we'd do is change this library's agent to
+// support content-sha256-secure redirect checking and have it happen for all
+// requests which aren't error, reference, s3 or azure artifact types.  This
+// would be done by writing a checkRedirect function which verified the
+// proposed redirect has valid and correct hashes and lengths then also redoing
+// https-checking by looking for a non-nil req.TLS value.  That's a pretty
+// large overhaul of how the library itself works, so what we're going to do
+// for the timebeing is have a second http client for running these types of
+// requests
+
 // New creates a Client for use
 func New(queue *tcqueue.Queue) *Client {
 	a := newAgent()
+	transport := &http.Transport{
+		MaxIdleConns:       10,
+		IdleConnTimeout:    30 * time.Second,
+		DisableCompression: true,
+	}
+	_client := &http.Client{
+		Transport: transport,
+	}
 	return &Client{
 		agent:                   a,
 		queue:                   queue,
 		chunkSize:               DefaultChunkSize,
 		multipartPartChunkCount: DefaultPartSize,
+		clientForBlindRedirects: _client,
 	}
 }
 
@@ -93,16 +113,53 @@ func (c *Client) GetInternalSizes() (int, int) {
 
 // Create an Error artifact.
 func (c *Client) CreateError(taskID, runID, name, reason, message string) error {
-	errorReq := &tcqueue.ErrorArtifactRequest{
+	errorreq := &tcqueue.ErrorArtifactRequest{
 		Expires:     tcclient.Time(time.Now().UTC().AddDate(0, 0, 1)),
 		Message:     message,
 		Reason:      reason,
 		StorageType: "error",
 	}
 
-	logger.Printf("%s", errorReq)
-	return nil
+	cap, err := json.Marshal(&errorreq)
+	if err != nil {
+		return newErrorf(err, "serializing json request body for createArtifact queue call during creation of error to %s/%s/%s", taskID, runID, name)
+	}
 
+	pareq := tcqueue.PostArtifactRequest(json.RawMessage(cap))
+
+	_, err = c.queue.CreateArtifact(taskID, runID, name, &pareq)
+	if err != nil {
+		return newErrorf(err, "making createArtifact queue call during error creation of %s/%s/%s", taskID, runID, name)
+	}
+
+	return nil
+}
+
+// Create a Reference artifact.
+func (c *Client) CreateReference(taskID, runID, name, url string) error {
+	refreq := &tcqueue.RedirectArtifactRequest{
+		// What?!? Why does a 302 redirect have a content-type???
+		// Since this doesn't really make any sense, we're just going to
+		// make up one which is safe
+		ContentType: "application/octet-stream",
+		Expires:     tcclient.Time(time.Now().UTC().AddDate(0, 0, 1)),
+		StorageType: "reference",
+		URL:         url,
+	}
+
+	cap, err := json.Marshal(&refreq)
+	if err != nil {
+		return newErrorf(err, "serializing json request body for createArtifact queue call during creation of reference %s/%s/%s", taskID, runID, name)
+	}
+
+	pareq := tcqueue.PostArtifactRequest(json.RawMessage(cap))
+
+	_, err = c.queue.CreateArtifact(taskID, runID, name, &pareq)
+	if err != nil {
+		return newErrorf(err, "making createArtifact queue call during reference creation of %s/%s/%s", taskID, runID, name)
+	}
+
+	return nil
 }
 
 // Upload an artifact.  The contents of input will be copied to the beginning
@@ -286,7 +343,9 @@ type stater interface {
 // in memory.  It is the callers responsibility to delete the contents of the
 // output on failure if needed.  If the output also implements the io.Seeker
 // interface, a check that the output is already empty will occur.  The most
-// common output option is likely an ioutil.TempFile() instance.
+// common output option is likely an ioutil.TempFile() instance.  If artifact
+// is an Error type, the contents of the error message will be written to the
+// output and the function will return an ErrErr method.
 func (c *Client) DownloadURL(u string, output io.Writer) error {
 
 	// If we can stat the output, let's see that the size is 0 bytes.  This is an
@@ -320,21 +379,26 @@ func (c *Client) DownloadURL(u string, output io.Writer) error {
 	var redirectBuf bytes.Buffer
 
 	cs, _, err := c.agent.run(request, nil, c.chunkSize, &redirectBuf, false)
-	if err != nil {
+
+	var storageType string
+	if cs.ResponseHeader != nil {
+		storageType = cs.ResponseHeader.Get("x-taskcluster-artifact-storage-type")
+	}
+
+	if err != nil && storageType != "error" {
 		logger.Printf("%s\n%s", cs, redirectBuf.String())
 		return newErrorf(err, "running redirect request for %s", u)
 	}
 
-	if storageType := cs.ResponseHeader.Get("x-taskcluster-artifact-storage-type"); storageType != "" {
-		logger.Printf("Storage Type: %s", storageType)
-	}
+	logger.Printf("Storage Type: %s", storageType)
 
-	if cs.StatusCode < 300 || cs.StatusCode >= 400 {
-		return ErrExpectedRedirect
+	// We have enough information at this point to determine if we have an error
+	// artifact type and how to handle it if so
+	if storageType == "error" {
+		io.Copy(output, &redirectBuf)
+		logger.Print("error artifact written")
+		return ErrErr
 	}
-
-	// Make sure we release the memory stored in the redirect buffer
-	redirectBuf.Reset()
 
 	location := cs.ResponseHeader.Get("Location")
 
@@ -351,6 +415,29 @@ func (c *Client) DownloadURL(u string, output io.Writer) error {
 		return ErrHTTPS
 	}
 
+	// For the reference, s3 and azure, there's nothing to check or verify.
+	if storageType == "reference" || storageType == "s3" || storageType == "azure" {
+		logger.Printf("following blind redirect of %s artifact", storageType)
+		resp, err := http.Get(location)
+		if err != nil {
+			return newErrorf(err, "fetching %s", location)
+		}
+		defer resp.Body.Close()
+		_, err = io.Copy(output, resp.Body)
+		if err != nil {
+			return newErrorf(err, "copying %s response body to output", location)
+		}
+		return nil
+	}
+
+	if cs.StatusCode < 300 || cs.StatusCode >= 400 {
+		return ErrExpectedRedirect
+	}
+
+	// Make sure we release the memory stored in the redirect buffer
+	redirectBuf.Reset()
+
+	// Now let's make the required request
 	request = newRequest(location, "GET", &http.Header{})
 
 	// Now we're going to request the artifact for real.  We're going to write directly

--- a/interface_test.go
+++ b/interface_test.go
@@ -138,6 +138,9 @@ func TestInterface(t *testing.T) {
 	})
 
 	t.Run("upload-blob", func(t *testing.T) {
+		if err = os.MkdirAll("testdata", os.FileMode(0755)); err != nil {
+			t.Fatal(err)
+		}
 
 		// We're not interested in logs
 		//SetLogOutput(ioutil.Discard)
@@ -148,7 +151,7 @@ func TestInterface(t *testing.T) {
 
 		t.Run("public/single-part-identity", func(t *testing.T) {
 			input := createInput(25) // 25MB
-			output, err := ioutil.TempFile(".", ".scratch")
+			output, err := ioutil.TempFile("testdata", ".scratch")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -163,7 +166,7 @@ func TestInterface(t *testing.T) {
 
 		t.Run("public/single-part-gzip", func(t *testing.T) {
 			input := createInput(25) // 25MB
-			output, err := ioutil.TempFile(".", ".scratch")
+			output, err := ioutil.TempFile("testdata", ".scratch")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -177,7 +180,7 @@ func TestInterface(t *testing.T) {
 
 		t.Run("public/multipart-identity", func(t *testing.T) {
 			input := createInput(25) // 25MB
-			output, err := ioutil.TempFile(".", ".scratch")
+			output, err := ioutil.TempFile("testdata", ".scratch")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -191,7 +194,7 @@ func TestInterface(t *testing.T) {
 
 		t.Run("public/multipart-gzip", func(t *testing.T) {
 			input := createInput(25) // 25MB
-			output, err := ioutil.TempFile(".", ".scratch")
+			output, err := ioutil.TempFile("testdata", ".scratch")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/interface_test.go
+++ b/interface_test.go
@@ -138,7 +138,7 @@ func TestInterface(t *testing.T) {
 	})
 
 	t.Run("upload-blob", func(t *testing.T) {
-		if err = os.MkdirAll("testdata", os.FileMode(0755)); err != nil {
+		if err = os.MkdirAll("testdata", 0755); err != nil {
 			t.Fatal(err)
 		}
 

--- a/interface_test.go
+++ b/interface_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
+	"testing"
 	"time"
 
 	"github.com/taskcluster/slugid-go/slugid"
@@ -13,11 +14,11 @@ import (
 	"github.com/taskcluster/taskcluster-client-go/tcqueue"
 )
 
-var taskGroupID = slugid.Nice()
-var taskID = slugid.Nice()
-var runID = "0"
+func setupEnvironment() (*tcqueue.Queue, string, string, error) {
+	taskGroupID := slugid.Nice()
+	taskID := slugid.Nice()
+	runID := "0"
 
-func setupEnvironment() (*tcqueue.Queue, error) {
 	// The first large amount of code is set up code to get you into the the
 	// correct task environment.  The expectation is that those using this
 	// library will already have this code set up
@@ -42,7 +43,7 @@ func setupEnvironment() (*tcqueue.Queue, error) {
 		Metadata: tcqueue.TaskMetadata{
 			Description: "taskcluster-lib-artifact-go example",
 			Name:        "taskcluster-lib-artifact-go example",
-			Owner:       "example",
+			Owner:       "example@example.com",
 			Source:      "https://github.com/taskcluster/taskcluster-lib-artifact-go",
 		},
 		Payload:       json.RawMessage(`{}`),
@@ -58,13 +59,13 @@ func setupEnvironment() (*tcqueue.Queue, error) {
 	}
 	_, err := q.CreateTask(taskID, taskDefinition)
 	if err != nil {
-		return nil, err
+		return nil, taskID, runID, err
 	}
 
 	tcr := tcqueue.TaskClaimRequest{WorkerGroup: "my-worker-group", WorkerID: "my-worker"}
 	tcres, err := q.ClaimTask(taskID, "0", &tcr)
 	if err != nil {
-		return nil, err
+		return nil, taskID, runID, err
 	}
 
 	taskQ := tcqueue.New(&tcclient.Credentials{
@@ -73,11 +74,11 @@ func setupEnvironment() (*tcqueue.Queue, error) {
 		Certificate: tcres.Credentials.Certificate,
 	})
 
-	return taskQ, nil
+	return taskQ, taskID, runID, nil
 
 }
 
-func createInput(size int) (*bytes.Reader, error) {
+func createInput(size int) *bytes.Reader {
 	var buf bytes.Buffer
 
 	// 25MB
@@ -87,92 +88,116 @@ func createInput(size int) (*bytes.Reader, error) {
 		_, err := rand.Read(rbuf)
 
 		if err != nil {
-			return nil, err
+			panic(err)
 		}
 
 		_, err = buf.Write(rbuf)
 		if err != nil {
-			return nil, err
+			panic(err)
 		}
 
 	}
 
-	return bytes.NewReader(buf.Bytes()), nil
+	return bytes.NewReader(buf.Bytes())
 }
 
-func ExampleClient_Upload() {
+func TestInterface(t *testing.T) {
 
 	// We need a task specific taskcluster-client-go Queue
-	taskQ, err := setupEnvironment()
+	taskQ, taskID, runID, err := setupEnvironment()
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	client := New(taskQ)
 
-	// We're going to create an input for uploading artifacts
-	input, err := createInput(25) // 25MB
-	if err != nil {
-		panic(err)
-	}
+	t.Run("create-error", func(t *testing.T) {
+		err = client.CreateError(taskID, runID, "public/error", "invalid-resource-on-worker", "test error message")
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 
-	output, err := ioutil.TempFile(".", ".scratch")
-	if err != nil {
-		panic(err)
-	}
-	defer os.Remove(output.Name())
+	t.Run("upload-blob", func(t *testing.T) {
 
-	// We're not interested in logs
-	SetLogOutput(ioutil.Discard)
+		// We're not interested in logs
+		SetLogOutput(ioutil.Discard)
 
-	// Let's tune the chunk and part size for our system so that we have 16KB
-	// chunks and 5MB parts
-	client.SetInternalSizes(16*1024, 5*1024*1024)
+		// Let's tune the chunk and part size for our system so that we have 16KB
+		// chunks and 5MB parts
+		client.SetInternalSizes(16*1024, 5*1024*1024)
 
-	// Let's upload the files four different ways
-	err = client.Upload(taskID, runID, "public/single-part-identity", input, output, false, false)
-	if err != nil {
-		panic(err)
-	}
+		t.Run("public/single-part-identity", func(t *testing.T) {
+			input := createInput(25) // 25MB
+			output, err := ioutil.TempFile(".", ".scratch")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(output.Name())
 
-	err = client.Upload(taskID, runID, "public/single-part-gzip", input, output, true, false)
-	if err != nil {
-		panic(err)
-	}
+			// Let's upload the files four different ways
+			err = client.Upload(taskID, runID, "public/single-part-identity", input, output, false, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
 
-	err = client.Upload(taskID, runID, "public/multipart-identity", input, output, false, true)
-	if err != nil {
-		panic(err)
-	}
+		t.Run("public/single-part-gzip", func(t *testing.T) {
+			input := createInput(25) // 25MB
+			output, err := ioutil.TempFile(".", ".scratch")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(output.Name())
 
-	err = client.Upload(taskID, runID, "public/multipart-gzip", input, output, true, true)
-	if err != nil {
-		panic(err)
-	}
-}
+			err = client.Upload(taskID, runID, "public/single-part-gzip", input, output, true, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
 
-func ExampleClient_Download() {
+		t.Run("public/multipart-identity", func(t *testing.T) {
+			input := createInput(25) // 25MB
+			output, err := ioutil.TempFile(".", ".scratch")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(output.Name())
 
-	var output bytes.Buffer
+			err = client.Upload(taskID, runID, "public/multipart-identity", input, output, false, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
 
-	// We don't need authenticated Queues for public downloads
-	client := New(nil)
+		t.Run("public/multipart-gzip", func(t *testing.T) {
+			input := createInput(25) // 25MB
+			output, err := ioutil.TempFile(".", ".scratch")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(output.Name())
 
-	err := client.Download(taskID, runID, "public/single-part-gzip", &output)
-	if err != nil {
-		panic(err)
-	}
-}
+			err = client.Upload(taskID, runID, "public/multipart-gzip", input, output, true, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	})
 
-func ExampleClient_DownloadLatest() {
+	t.Run("download-blob", func(t *testing.T) {
+		var output bytes.Buffer
+		err := client.Download(taskID, runID, "public/single-part-gzip", &output)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 
-	var output bytes.Buffer
-
-	// We don't need authenticated Queues for public downloads
-	client := New(nil)
-
-	err := client.DownloadLatest(taskID, "public/single-part-gzip", &output)
-	if err != nil {
-		panic(err)
-	}
+	t.Run("download-blob-latest", func(t *testing.T) {
+		var output bytes.Buffer
+		err := client.DownloadLatest(taskID, "public/single-part-gzip", &output)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 }

--- a/interface_test.go
+++ b/interface_test.go
@@ -111,8 +111,27 @@ func TestInterface(t *testing.T) {
 
 	client := New(taskQ)
 
-	t.Run("create-error", func(t *testing.T) {
+	t.Run("error-artifacts", func(t *testing.T) {
 		err = client.CreateError(taskID, runID, "public/error", "invalid-resource-on-worker", "test error message")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var output bytes.Buffer
+		err = client.Download(taskID, runID, "public/error", &output)
+		if err != ErrErr {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("reference-artifacts", func(t *testing.T) {
+		err = client.CreateReference(taskID, runID, "public/reference", "https://www.google.com")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var output bytes.Buffer
+		err = client.Download(taskID, runID, "public/reference", &output)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -121,7 +140,7 @@ func TestInterface(t *testing.T) {
 	t.Run("upload-blob", func(t *testing.T) {
 
 		// We're not interested in logs
-		SetLogOutput(ioutil.Discard)
+		//SetLogOutput(ioutil.Discard)
 
 		// Let's tune the chunk and part size for our system so that we have 16KB
 		// chunks and 5MB parts

--- a/prepare_test.go
+++ b/prepare_test.go
@@ -36,6 +36,10 @@ func testUpload(t *testing.T, gzip bool, mp bool, filename string) {
 	}
 	defer input.Close()
 
+	if err = os.MkdirAll("testdata", os.FileMode(0755)); err != nil {
+		t.Fatal(err)
+	}
+
 	output, err := ioutil.TempFile("testdata", "sp-gz_")
 
 	t.Log(output.Name())

--- a/prepare_test.go
+++ b/prepare_test.go
@@ -36,7 +36,7 @@ func testUpload(t *testing.T, gzip bool, mp bool, filename string) {
 	}
 	defer input.Close()
 
-	if err = os.MkdirAll("testdata", os.FileMode(0755)); err != nil {
+	if err = os.MkdirAll("testdata", 0755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/request_test.go
+++ b/request_test.go
@@ -59,6 +59,10 @@ func TestRequestRunning(t *testing.T) {
 
 	client := newAgent()
 
+	if err := os.MkdirAll("testdata", os.FileMode(0755)); err != nil {
+		t.Fatal(err)
+	}
+
 	filename := "testdata/request.dat"
 
 	// We want to do a little bit of setup before running the tests

--- a/request_test.go
+++ b/request_test.go
@@ -59,7 +59,7 @@ func TestRequestRunning(t *testing.T) {
 
 	client := newAgent()
 
-	if err := os.MkdirAll("testdata", os.FileMode(0755)); err != nil {
+	if err := os.MkdirAll("testdata", 0755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/testdata/readme
+++ b/testdata/readme
@@ -1,4 +1,0 @@
-This directory is used to store scratch files for the unit tests of this
-library.  Nothing important is stored in here.  We do this instead of using
-/tmp to make sure that the /tmp mount doesn't get filled up with a bunch of big
-files


### PR DESCRIPTION
This PR fixes a couple of issues, firstly that the interface_tests.go test files weren't running.  I've decided to convert them into full unit tests instead.  The rest of this patch is to support using non-blob artifacts.  As noted in the comments, the ideal solution would be to have a checkRedirect handler that supported all the various incarnations of our headers for specifying the content and transfer hashes and lengths.  That's a different PR, though.

If you have any questions, please let me know.