### PR TITLE
Bug 1487028 - document command line tool availability for taskcluster-lib-artifact-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
-# taskcluster-lib-api-go
-
 [![Taskcluster CI Status](https://github.taskcluster.net/v1/repository/taskcluster/taskcluster-lib-artifact-go/master/badge.svg)](https://github.taskcluster.net/v1/repository/taskcluster/taskcluster-lib-artifact-go/master/latest)
 [![GoDoc](https://godoc.org/github.com/taskcluster/taskcluster-lib-artifact-go?status.svg)](https://godoc.org/github.com/taskcluster/taskcluster-lib-artifact-go)
 [![License](https://img.shields.io/badge/license-MPL%202.0-orange.svg)](http://mozilla.org/MPL/2.0)
-
 # artifact
 `import "github.com/taskcluster/taskcluster-lib-artifact-go"`
 
@@ -17,25 +14,26 @@ Package artifact provides an interface for working with the Taskcluster
 Queue's blob artifacts.  Blob artifacts are the way that Taskcluster stores
 and distributes the results of a task and replace the old "S3" type of
 artifact for storing artifacts in S3.  These artifacts have stronger
-authenticity and integrity guaruntees than the old type.
+authenticity and integrity guaruntees than the former type.
 
 ### Overview of Blob Artifacts
 Blob artifacts can be between 1 byte and 5GB if uploaded as a single part
 upload and between 1 byte and 5TB if uploaded as a multipart upload.  To
-upload this type of artifact, the uploader must compute the artifacts sha256
-and size before and after optional gzip compression.  The sha256 and size
-values are used by the Queue to generate a set of requests which get sent
-back to the uploader which can be used to upload the artifact.  This ensures
-that network interuptions or corruption result in errors when uploading.
-Once the uploads have completed, the uploader must tell the Queue that the
-upload is complete.
+upload this type of artifact, the uploader must compute the artifact's
+sha256 and size before and after optional gzip compression.  The sha256 and
+size values are used by the Queue to generate a set of requests which get
+sent back to the uploader which can be used to upload the artifact.  This
+ensures that network interuptions or corruption result in errors when
+uploading.  Once the uploads have completed, the uploader must tell the
+Queue that the upload is complete.
 
 The queue ensures that the sha256 and size values are set as headers on the
-artifacts in S3 so that downloaders can do verification
+artifacts in S3 so that downloaded content can be verified.
 
-When downloading a blob artifact, the downloader must verify that the
-artifact downloaded has the same sha256 and sizes before and after optional
-gzip decompression.
+While downloading, the downloader should be counting the number of bytes as
+well as hashing the incoming artifact to determine the sha256 and size to compare
+to the expected values on completion of the request.  It is imperative that
+the downloader perform these verifications
 
 Interacting with this API correctly is sufficiently complicated that this
 library is the only supported way to upload or download artifacts using Go.
@@ -62,14 +60,18 @@ This package automatically decompresses artifacts which are stored with a
 content encoding of 'gzip'.  In both uploading and downloading, the gzip
 encoding and decoding is done independently of any gzip encoding by the
 calling code.  This could result in double gzip encoding if a gzip file is
-passed into Upload() with the gzip argument set to true.  When this artifact
-is downloaded with this library, the resulting output will be written as a
-once encoded gzip file
+passed into Upload() with the gzip argument set to true.
+
+### Command line application
+This library also includes a command line application.  The code for it is
+located in the cmd/artifact directory.  This command line tool can be
+installed into $GOPATH/bin/artifact by running the command 'go install
+github.com/taskcluster/taskcluster-lib-artifact-go/cmd/artifact'
 
 ## <a name="pkg-imports">Imported Packages</a>
 
 - [github.com/taskcluster/taskcluster-client-go](./../taskcluster-client-go)
-- [github.com/taskcluster/taskcluster-client-go/queue](./../taskcluster-client-go/queue)
+- [github.com/taskcluster/taskcluster-client-go/tcqueue](./../taskcluster-client-go/tcqueue)
 
 ## <a name="pkg-index">Index</a>
 * [Constants](#pkg-constants)
@@ -77,10 +79,12 @@ once encoded gzip file
 * [func SetLogFlags(f int)](#SetLogFlags)
 * [func SetLogOutput(w io.Writer)](#SetLogOutput)
 * [func SetLogPrefix(p string)](#SetLogPrefix)
+* [func SetLogger(l \*log.Logger) error](#SetLogger)
 * [type Client](#Client)
-  * [func New(queue \*queue.Queue) \*Client](#New)
+  * [func New(queue \*tcqueue.Queue) \*Client](#New)
   * [func (c \*Client) Download(taskID, runID, name string, output io.Writer) error](#Client.Download)
   * [func (c \*Client) DownloadLatest(taskID, name string, output io.Writer) error](#Client.DownloadLatest)
+  * [func (c \*Client) DownloadURL(u string, output io.Writer) error](#Client.DownloadURL)
   * [func (c \*Client) GetInternalSizes() (int, int)](#Client.GetInternalSizes)
   * [func (c \*Client) SetInternalSizes(chunkSize, partSize int) error](#Client.SetInternalSizes)
   * [func (c \*Client) Upload(taskID, runID, name string, input io.ReadSeeker, output io.ReadWriteSeeker, gzip, multipart bool) error](#Client.Upload)
@@ -91,7 +95,7 @@ once encoded gzip file
 * [Client.Upload](#example_Client_Upload)
 
 #### <a name="pkg-files">Package files</a>
-[body.go](./body.go) [bytecounter.go](./bytecounter.go) [docs.go](./docs.go) [errors.go](./errors.go) [interface.go](./interface.go) [log.go](./log.go) [prepare.go](./prepare.go) [request.go](./request.go) [test_logger.go](./test_logger.go) 
+[body.go](./body.go) [bytecounter.go](./bytecounter.go) [docs.go](./docs.go) [error.go](./error.go) [errors.go](./errors.go) [interface.go](./interface.go) [log.go](./log.go) [namer.go](./namer.go) [prepare.go](./prepare.go) [request.go](./request.go) [test_logger.go](./test_logger.go) 
 
 ## <a name="pkg-constants">Constants</a>
 ``` go
@@ -106,40 +110,45 @@ DefaultPartSize is 100MB
 
 ## <a name="pkg-variables">Variables</a>
 ``` go
-var ErrBadOutputWriter = errors.New("output writer is not empty")
+var ErrBadOutputWriter = newError(nil, "output writer is not empty")
 ```
 ErrBadOutputWriter is returned when the output writer passed into a function
 was able to be checked for its size and it contained more than 0 bytes
 
 ``` go
-var ErrBadRedirect = errors.New("malformed redirect")
+var ErrBadRedirect = newError(nil, "malformed redirect")
 ```
 ErrBadRedirect is returned when a malformed redirect is received.  Example
 would be an empty Location: header or a Location: header with an invalid URL
 as its value
 
 ``` go
-var ErrCorrupt = errors.New("corrupt resource")
+var ErrBadSize = newError(nil, "invalid part or chunk size")
+```
+ErrBadSize is returned when a part size or chunk size is invalid
+
+``` go
+var ErrCorrupt = newError(nil, "corrupt resource")
 ```
 ErrCorrupt is returned when an artifact is corrupt
 
 ``` go
-var ErrExpectedRedirect = errors.New("expected redirect")
+var ErrExpectedRedirect = newError(nil, "expected redirect")
 ```
 ErrExpectedRedirect is returned when a redirect is expected but not received
 
 ``` go
-var ErrHTTPS = errors.New("only resources served over https are allowed")
+var ErrHTTPS = newError(nil, "only resources served over https are allowed")
 ```
 ErrHTTPS is returned when a non-https url is involved in a redirect
 
 ``` go
-var ErrUnexpectedRedirect = errors.New("unexpected redirect")
+var ErrUnexpectedRedirect = newError(nil, "unexpected redirect")
 ```
 ErrUnexpectedRedirect is returned when we expect a redirect but do not
 receive one
 
-## <a name="SetLogFlags">func</a> [SetLogFlags](./log.go#L36)
+## <a name="SetLogFlags">func</a> [SetLogFlags](./log.go#L37)
 ``` go
 func SetLogFlags(f int)
 ```
@@ -147,7 +156,7 @@ SetLogFlags will change the flags which are used by logs in this package
 This is a simple convenience method to wrap this package's Logger instance's
 method.  See: <a href="https://golang.org/pkg/log/#Logger.SetFlags">https://golang.org/pkg/log/#Logger.SetFlags</a>
 
-## <a name="SetLogOutput">func</a> [SetLogOutput](./log.go#L22)
+## <a name="SetLogOutput">func</a> [SetLogOutput](./log.go#L23)
 ``` go
 func SetLogOutput(w io.Writer)
 ```
@@ -159,7 +168,7 @@ do the following:
 
 	SetLogOutput(ioutil.Discard)
 
-## <a name="SetLogPrefix">func</a> [SetLogPrefix](./log.go#L29)
+## <a name="SetLogPrefix">func</a> [SetLogPrefix](./log.go#L30)
 ``` go
 func SetLogPrefix(p string)
 ```
@@ -167,21 +176,29 @@ SetLogPrefix will change the prefix used by logs in this package This is a
 simple convenience method to wrap this package's Logger instance's method.
 See: <a href="https://golang.org/pkg/log/#Logger.SetPrefix">https://golang.org/pkg/log/#Logger.SetPrefix</a>
 
-## <a name="Client">type</a> [Client](./interface.go#L35-L40)
+## <a name="SetLogger">func</a> [SetLogger](./log.go#L42)
+``` go
+func SetLogger(l *log.Logger) error
+```
+SetLogger replaces the current logger with the logger specified
+
+## <a name="Client">type</a> [Client](./interface.go#L37-L43)
 ``` go
 type Client struct {
+    AllowInsecure bool
     // contains filtered or unexported fields
 }
+
 ```
 Client knows how to upload and download blob artifacts
 
-### <a name="New">func</a> [New](./interface.go#L49)
+### <a name="New">func</a> [New](./interface.go#L52)
 ``` go
-func New(queue *queue.Queue) *Client
+func New(queue *tcqueue.Queue) *Client
 ```
 New creates a Client for use
 
-### <a name="Client.Download">func</a> (\*Client) [Download](./interface.go#L342)
+### <a name="Client.Download">func</a> (\*Client) [Download](./interface.go#L360)
 ``` go
 func (c *Client) Download(taskID, runID, name string, output io.Writer) error
 ```
@@ -191,9 +208,10 @@ will be written instead of the artifact's content.  This is so that we can
 stream the response to the output instead of buffering it in memory.  It is
 the callers responsibility to delete the contents of the output on failure
 if needed.  If the output also implements the io.Seeker interface, a check
-that the output is already empty will occur
+that the output is already empty will occur.  The most common output option
+is likely an ioutil.TempFile() instance.
 
-### <a name="Client.DownloadLatest">func</a> (\*Client) [DownloadLatest](./interface.go#L366)
+### <a name="Client.DownloadLatest">func</a> (\*Client) [DownloadLatest](./interface.go#L385)
 ``` go
 func (c *Client) DownloadLatest(taskID, name string, output io.Writer) error
 ```
@@ -203,16 +221,32 @@ error message will be written instead of the artifact's content.  This is so
 that we can stream the response to the output instead of buffering it in
 memory.  It is the callers responsibility to delete the contents of the
 output on failure if needed.  If the output also implements the io.Seeker
-interface, a check that the output is already empty will occur
+interface, a check that the output is already empty will occur.  The most
+common output option is likely an ioutil.TempFile() instance.
 
-### <a name="Client.GetInternalSizes">func</a> (\*Client) [GetInternalSizes](./interface.go#L87)
+### <a name="Client.DownloadURL">func</a> (\*Client) [DownloadURL](./interface.go#L275)
+``` go
+func (c *Client) DownloadURL(u string, output io.Writer) error
+```
+DownloadURL downloads a URL to the specified output.  Because we generate
+different URLs based on whether we're asking for latest or not DownloadURL
+will take a string that is a Queue URL to an artifact and download it to the
+outputWriter.  If an error occurs during the download, the response body of
+the error message will be written instead of the artifact's content.  This
+is so that we can stream the response to the output instead of buffering it
+in memory.  It is the callers responsibility to delete the contents of the
+output on failure if needed.  If the output also implements the io.Seeker
+interface, a check that the output is already empty will occur.  The most
+common output option is likely an ioutil.TempFile() instance.
+
+### <a name="Client.GetInternalSizes">func</a> (\*Client) [GetInternalSizes](./interface.go#L90)
 ``` go
 func (c *Client) GetInternalSizes() (int, int)
 ```
 GetInternalSizes returns the chunkSize and partSize, respectively, for this
 Client.
 
-### <a name="Client.SetInternalSizes">func</a> (\*Client) [SetInternalSizes](./interface.go#L67)
+### <a name="Client.SetInternalSizes">func</a> (\*Client) [SetInternalSizes](./interface.go#L70)
 ``` go
 func (c *Client) SetInternalSizes(chunkSize, partSize int) error
 ```
@@ -225,7 +259,7 @@ that we don't have to worry about each individual read or write being split
 across more than one part.  Both are changed in a single call because the
 partSize must always be a multiple of the chunkSize
 
-### <a name="Client.Upload">func</a> (\*Client) [Upload](./interface.go#L97)
+### <a name="Client.Upload">func</a> (\*Client) [Upload](./interface.go#L101)
 ``` go
 func (c *Client) Upload(taskID, runID, name string, input io.ReadSeeker, output io.ReadWriteSeeker, gzip, multipart bool) error
 ```
@@ -234,75 +268,8 @@ of output, optionally with gzip encoding.  Output must be an
 io.ReadWriteSeeker which has 0 bytes (thus position 0).  We need the output
 to be able to Read, Write and Seek because we'll pass over the file one time
 to copy it to the output, then seek back to the beginning and read it in
-again for the upload
+again for the upload.  When this artifact is downloaded with this library,
+the resulting output will be written as a once encoded gzip file
 
 - - -
 Generated by [godoc2ghmd](https://github.com/GandalfUK/godoc2ghmd)
-
-
-# Setting up a development environment
-
-* Head over to http://golang.org/doc/install and follow the instructions for your platform
-* Be sure to set your GOPATH to something appropriate
-* Run `go get github.com/taskcluster/taskcluster-lib-artifact-go`. Do *NOT* `go get` your personal fork since that will break package names.
-
-All being well, the `artifact` or `artifact.exe` binary will be built under `${GOPATH}/bin`. The sources will be under `${GOPATH}/src/github.com/taskcluster/taskcluster-lib-artifact-go`.
-
-To work on your own fork of the code:
-
-```
-$ cd "${GOPATH}/src/github.com/taskcluster/taskcluster-lib-artifact-go"
-$ git remote add myfork <git url of your fork>
-$ git fetch myfork
-$ git checkout -t mybranch myfork/mybranch
-```
-
-# Acquire taskcluster credentials for running tests
-
-There are two alternative mechanisms to acquire the scopes you need.
-
-## Option 1
-
-This method works if you log into Taskcluster via mozillians, *or* you log into
-taskcluster via LDAP *using the same email address as your mozillians account*,
-*or* if you do not currently have a mozillians account but would like to create
-one.
-
-* Sign up for a [Mozillians account](https://mozillians.org/en-US/) (if you do not already have one)
-* Request membership of the [taskcluster-contributors](https://mozillians.org/en-US/group/taskcluster-contributors/) mozillians group
-
-## Option 2
-
-This method is for those who wish not to create a mozillians account, but
-already authenticate into taskcluster via some other means, or have a
-mozillians account but it is registered to a different email address than the
-one they use to log into Taskcluster with (e.g. via LDAP integration).
-
-* Request the scope `assume:project:taskcluster:taskcluster-lib-artifact-go-tester` to be
-  granted to you via a [bugzilla
-  request](https://bugzilla.mozilla.org/enter_bug.cgi?product=Taskcluster&component=Service%20Request),
-  including your [currently active `ClientId`](https://tools.taskcluster.net/credentials/)
-  in the bug description. From the ClientId, we will be able to work out which role to assign the scope
-  to, in order that you acquire the scope with the client you log into Taskcluster tools site with.
-
-Once you have been granted the above scope:
-
-* If you are signed into tools.taskcluster.net already, **sign out**
-* Sign into [tools.taskcluster.net](https://tools.taskcluster.net/) using either your new Mozillians account, _or_ your LDAP account **if it uses the same email address as your Mozillians account**
-* Check that a role or client of yours appears in [this list](https://tools.taskcluster.net/auth/scopes/assume%3Aproject%3Ataskcluster%3Ataskcluster-lib-artifact-go-tester)
-* Optional: Create a permanent client (taskcluster credentials) for yourself in the [Client Manager](https://tools.taskcluster.net/auth/clients/) granting it the single scope `assume:project:taskcluster:taskcluster-lib-artifact-go-tester`
-
-Now update your environment:
-
-```
-export TASKCLUSTER_CLIENT_ID=......
-export TASKCLUSTER_ACCESS_TOKEN=.......
-export TASKCLUSTER_CERTIFICATE=....... (if using temporary credentials)
-```
-
-Now you should be able to run tests locally:
-
-```
-cd "${GOPATH}/src/github.com/taskcluster/taskcluster-lib-artifact-go"
-go test -v ./...
-```

--- a/docs.go
+++ b/docs.go
@@ -52,4 +52,11 @@
 // encoding and decoding is done independently of any gzip encoding by the
 // calling code.  This could result in double gzip encoding if a gzip file is
 // passed into Upload() with the gzip argument set to true.
+//
+// Command line application
+//
+// This library also includes a command line application.  The code for it is
+// located in the cmd/artifact directory.  This command line tool can be
+// installed into $GOPATH/bin/artifact by running the command 'go install
+// github.com/taskcluster/taskcluster-lib-artifact-go/cmd/artifact'
 package artifact

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 
-
 echo Updating dependencies
 go get -u ./...
 go get -u github.com/golang/lint/golint
@@ -14,11 +13,18 @@ go test ./...
 
 echo Linting
 golint --min_confidence=0.3 ./...
-go vet ./...
 
 echo Running govet
+go vet ./...
+
 
 go get -u github.com/robertkrimen/godocdown/godocdown
 
-godoc2ghmd $(git config --get remote.origin.url | sed "s,^https://,, ; s,:,/,") > README.md
+cat << EOF > README.md
+[![Taskcluster CI Status](https://github.taskcluster.net/v1/repository/taskcluster/taskcluster-lib-artifact-go/master/badge.svg)](https://github.taskcluster.net/v1/repository/taskcluster/taskcluster-lib-artifact-go/master/latest)
+[![GoDoc](https://godoc.org/github.com/taskcluster/taskcluster-lib-artifact-go?status.svg)](https://godoc.org/github.com/taskcluster/taskcluster-lib-artifact-go)
+[![License](https://img.shields.io/badge/license-MPL%202.0-orange.svg)](http://mozilla.org/MPL/2.0)
+
+EOF
+godoc2ghmd $(git config --get remote.origin.url | sed "s,^https://,, ; s,:,/,") >> README.md
 


### PR DESCRIPTION
This patch also fixes readme.md generation to include the information headers at the beginning