### PR TITLE
Bug 1523559 - update to work with redeployable taskcluster-client-go

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -27,8 +27,8 @@ tasks:
           - pull_request.synchronize
           - push
     scopes:
-      - secrets:get:repo:github.com/taskcluster/taskcluster-lib-artifact-go
       - generic-worker:cache:taskcluster-lib-artifact-go-checkout
+      - assume:project:taskcluster:taskcluster-lib-artifact-go-tester
     payload:
       features:
         taskclusterProxy: true
@@ -41,9 +41,6 @@ tasks:
         - git config --global core.autocrlf false
         - go version
         - go env
-        # extract .bat file from secret repo:github.com/taskcluster/taskcluster-lib-artifact-go
-        - 'type secrets | jq -r .secret.bat > env.bat' 
-        - env.bat
         - 'if not exist "%GOPATH%\src\github.com\taskcluster" mkdir "%GOPATH%\src\github.com\taskcluster"'
         - 'cd "%GOPATH%\src\github.com\taskcluster"'
         - 'if not exist taskcluster-lib-artifact-go git clone {{ event.head.repo.url }} taskcluster-lib-artifact-go'
@@ -84,10 +81,6 @@ tasks:
           directory: git
           format: zip
         - content:
-            url: http://taskcluster/secrets/v1/secret/repo:github.com/taskcluster/taskcluster-lib-artifact-go
-            sha256: ea77921a6e81d3f70989c661e0f179f645a9c5083d9ccae0f276dc79efc1a589
-          file: secrets
-        - content:
             url: https://github.com/stedolan/jq/releases/download/jq-1.5/jq-win64.exe
             sha256: ebecd840ba47efbf66822868178cc721a151060937f7ac406e3d31bd015bde94
           file: jq.exe
@@ -111,8 +104,8 @@ tasks:
           - pull_request.synchronize
           - push
     scopes:
-      - secrets:get:repo:github.com/taskcluster/taskcluster-lib-artifact-go
       - generic-worker:cache:taskcluster-lib-artifact-go-checkout
+      - assume:project:taskcluster:taskcluster-lib-artifact-go-tester
     payload:
       features:
         taskclusterProxy: true
@@ -127,8 +120,6 @@ tasks:
             export PATH="${GOPATH}/bin:${GOROOT}/bin:${PATH}"
             go version
             go env
-            cat secrets | jq -r .secret.sh > env.sh
-            source env.sh
             mkdir -p "${GOPATH}/src/github.com/taskcluster"
             cd "${GOPATH}/src/github.com/taskcluster"
             if [ ! -d taskcluster-lib-artifact-go/.git ]; then rm -rf taskcluster-lib-artifact-go; git clone '{{ event.head.repo.url }}' 'taskcluster-lib-artifact-go'; fi
@@ -155,10 +146,6 @@ tasks:
           directory: go1.10.1
           format: tar.gz
         - content:
-            url: http://localhost:8080/secrets/v1/secret/repo:github.com/taskcluster/taskcluster-lib-artifact-go
-            sha256: ea77921a6e81d3f70989c661e0f179f645a9c5083d9ccae0f276dc79efc1a589
-          file: secrets
-        - content:
             url: https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64
             sha256: 386e92c982a56fe4851468d7a931dfca29560cee306a0e66c6a1bd4065d3dac5
           file: jq
@@ -182,8 +169,8 @@ tasks:
           - pull_request.synchronize
           - push
     scopes:
-      - secrets:get:repo:github.com/taskcluster/taskcluster-lib-artifact-go
       - docker-worker:cache:taskcluster-lib-artifact-go-checkout
+      - assume:project:taskcluster:taskcluster-lib-artifact-go-tester
     payload:
       features:
         taskclusterProxy: true
@@ -198,8 +185,6 @@ tasks:
           go env
           curl -sL https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 > /usr/bin/jq
           chmod u+x /usr/bin/jq
-          curl -sL http://taskcluster/secrets/v1/secret/repo:github.com/taskcluster/taskcluster-lib-artifact-go | /usr/bin/jq -r .secret.sh > env.sh
-          source env.sh
           mkdir -p "${GOPATH}/src/github.com/taskcluster"
           cd "${GOPATH}/src/github.com/taskcluster"
           if [ ! -d taskcluster-lib-artifact-go/.git ]; then rm -rf taskcluster-lib-artifact-go; git clone '{{ event.head.repo.url }}' 'taskcluster-lib-artifact-go'; fi

--- a/cmd/artifact/main.go
+++ b/cmd/artifact/main.go
@@ -65,6 +65,11 @@ func _main(args []string) error {
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
+			Name:   "root-url",
+			EnvVar: "TASKCLUSTER_ROOT_URL",
+			Usage:  "set root URL to `ROOT_URL`",
+		},
+		cli.StringFlag{
 			Name:   "client-id",
 			EnvVar: "TASKCLUSTER_CLIENT_ID",
 			Usage:  "set client id to `CLIENT_ID`",
@@ -82,8 +87,7 @@ func _main(args []string) error {
 		cli.StringFlag{
 			Name:   "base-url",
 			EnvVar: "QUEUE_BASE_URL",
-			Usage:  "set queue's `BASE_URL`",
-			Value:  tcqueue.DefaultBaseURL,
+			Usage:  "set queue's `BASE_URL` (takes precedence over `ROOT_URL`)",
 		},
 		cli.StringFlag{
 			Name:   "chunk-size",
@@ -139,7 +143,7 @@ func _main(args []string) error {
 					ClientID:    c.GlobalString("client-id"),
 					AccessToken: c.GlobalString("access-token"),
 					Certificate: c.GlobalString("certificate"),
-				})
+				}, c.GlobalString("root-url"))
 
 				if c.GlobalIsSet("base-url") {
 					q.BaseURL = c.GlobalString("base-url")
@@ -148,7 +152,8 @@ func _main(args []string) error {
 				client := artifact.New(q)
 
 				if c.GlobalIsSet("chunk-size") {
-					cz, err := units.ParseBase2Bytes(c.String("chunk-size"))
+					var cz units.Base2Bytes
+					cz, err = units.ParseBase2Bytes(c.String("chunk-size"))
 					if err != nil {
 						return cli.NewExitError(err.Error(), ErrInternal)
 					}
@@ -253,7 +258,11 @@ func _main(args []string) error {
 					ClientID:    c.GlobalString("client-id"),
 					AccessToken: c.GlobalString("access-token"),
 					Certificate: c.GlobalString("certificate"),
-				})
+				}, c.GlobalString("root-url"))
+
+				if c.GlobalIsSet("base-url") {
+					q.BaseURL = c.GlobalString("base-url")
+				}
 
 				client := artifact.New(q)
 
@@ -307,7 +316,8 @@ func _main(args []string) error {
 				}
 
 				if c.GlobalIsSet("part-size") {
-					ps, err := units.ParseBase2Bytes(c.String("part-size"))
+					var ps units.Base2Bytes
+					ps, err = units.ParseBase2Bytes(c.String("part-size"))
 					if err != nil {
 						return cli.NewExitError(err.Error(), ErrInternal)
 					}

--- a/integration/interface_test.go
+++ b/integration/interface_test.go
@@ -175,7 +175,7 @@ func createTask(t *testing.T, taskGroupID, taskID, runID string) *tcqueue.Queue 
 		ClientID:    tcres.Credentials.ClientID,
 		AccessToken: tcres.Credentials.AccessToken,
 		Certificate: tcres.Credentials.Certificate,
-	})
+	}, os.Getenv("TASKCLUSTER_ROOT_URL"))
 	return taskQ
 }
 

--- a/interface_test.go
+++ b/interface_test.go
@@ -72,7 +72,7 @@ func setupEnvironment() (*tcqueue.Queue, string, string, error) {
 		ClientID:    tcres.Credentials.ClientID,
 		AccessToken: tcres.Credentials.AccessToken,
 		Certificate: tcres.Credentials.Certificate,
-	})
+	}, os.Getenv("TASKCLUSTER_ROOT_URL"))
 
 	return taskQ, taskID, runID, nil
 


### PR DESCRIPTION
Hi John!

This updates taskcluster-lib-artifact-go to work with the breaking changes introduced in taskcluster-client-go.

Note, it also updates the CI to not use a client ID and access token that are stored in taskcluster-secrets service, rather it uses the taskcluster proxy transparently for the tests, and the CI tasks now have the scopes to run the tests. This is now possible since the taskcluster-client can work transparently with the proxy, which was not the case before RFC128.

See [bug 1523559](https://bugzil.la/1523559). Many thanks!